### PR TITLE
feat: Convert algorithm configs to Pydantic and register in FastAPI

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,10 @@ import logging
 from fastapi import FastAPI, WebSocket, HTTPException
 
 from pydantic_schemas.configs.linear_regression_configs import LinearRegressionParams
+from api.pydantic_schemas.configs.decision_tree_config import DecisionTreeParams
+from api.pydantic_schemas.configs.k_nearest_neighbour_config import KNeighborsParams
+from api.pydantic_schemas.configs.kmeans_config import KMeansParams
+from api.pydantic_schemas.configs.logistic_regression_config import LogisticRegressionParams # Added import
 from pydantic_schemas.interface.algorithm_interface import AlgorithmInfo
 
 from typing import Dict, List, Type
@@ -26,6 +30,38 @@ ALGORITHM_REGISTRY: Dict[str, AlgorithmRegistryEntry] = {
             description="A simple linear regression model."
         ),
         LinearRegressionParams
+    ),
+    "decision_tree": AlgorithmRegistryEntry(
+        AlgorithmInfo(
+            internal_name="decision_tree",
+            display_name="Decision Tree",
+            description="A decision tree algorithm for classification and regression."
+        ),
+        DecisionTreeParams
+    ),
+    "k_nearest_neighbours": AlgorithmRegistryEntry(
+        AlgorithmInfo(
+            internal_name="k_nearest_neighbours",
+            display_name="K-Nearest Neighbours",
+            description="A k-nearest neighbours algorithm for classification and regression."
+        ),
+        KNeighborsParams
+    ),
+    "kmeans": AlgorithmRegistryEntry(
+        AlgorithmInfo(
+            internal_name="kmeans",
+            display_name="K-Means Clustering",
+            description="A k-means clustering algorithm to partition data into k clusters."
+        ),
+        KMeansParams
+    ),
+    "logistic_regression": AlgorithmRegistryEntry(
+        AlgorithmInfo(
+            internal_name="logistic_regression",
+            display_name="Logistic Regression",
+            description="A logistic regression algorithm for binary classification."
+        ),
+        LogisticRegressionParams
     ),
 }
 # Configure logging

--- a/api/pydantic_schemas/configs/decision_tree_config.py
+++ b/api/pydantic_schemas/configs/decision_tree_config.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from pydantic import Field
+from api.pydantic_schemas.configs.algorithm_configs import SupervisedAlgorithmsParams
+
+
+class DecisionTreeParams(SupervisedAlgorithmsParams):
+    """
+    Pydantic model for Decision Tree parameters.
+
+    Attributes:
+        max_tree_depth: Maximum depth of a tree (default: None). Must be a positive integer if set.
+        min_leaf_samples: Minimal number of samples needed to create new leaf (default: 1). Must be > 0.
+        min_split_samples: Minimal number of samples needed to make a split (default: 2). Must be > 0.
+    """
+
+    max_tree_depth: Optional[int] = Field(
+        default=None,
+        description="Maximum depth of a tree. If set, must be a positive integer.",
+        gt=0
+    )
+    min_leaf_samples: int = Field(
+        default=1,
+        description="Minimal number of samples needed to create new leaf.",
+        gt=0
+    )
+    min_split_samples: int = Field(
+        default=2,
+        description="Minimal number of samples needed to make a split.",
+        gt=0
+    )

--- a/api/pydantic_schemas/configs/k_nearest_neighbour_config.py
+++ b/api/pydantic_schemas/configs/k_nearest_neighbour_config.py
@@ -1,0 +1,49 @@
+from typing import Literal, Optional
+
+from pydantic import Field
+from api.pydantic_schemas.configs.algorithm_configs import SupervisedAlgorithmsParams
+
+# Define custom types for clarity, mirroring the dataclass version
+KNNWeightType = Literal['uniform', 'distance']
+KNNAlgorithmType = Literal['auto', 'ball_tree', 'kd_tree', 'brute']
+KNNMetricType = Literal['minkowski', 'euclidean', 'manhattan', 'chebyshev']
+
+class KNeighborsParams(SupervisedAlgorithmsParams):
+    """
+    Pydantic model for K-Nearest Neighbors (KNN) algorithm parameters.
+
+    Attributes:
+        n_neighbors: Number of neighbors to use (default: 5). Must be positive.
+        weights: Weight function used in prediction ('uniform', 'distance').
+        algorithm: Algorithm used to compute the nearest neighbors ('auto', 'ball_tree', 'kd_tree', 'brute').
+        leaf_size: Leaf size passed to BallTree or KDTree (default: 30). Must be positive.
+        p: Power parameter for the Minkowski metric (default: 2). When p=1, this is equivalent to using manhattan_distance (L1), and euclidean_distance (L2) for p=2. Must be >= 1.
+        metric: The distance metric to use for the tree.
+    """
+    n_neighbors: int = Field(
+        default=5,
+        description="Number of neighbors to use.",
+        gt=0
+    )
+    weights: KNNWeightType = Field(
+        default='uniform',
+        description="Weight function used in prediction. 'uniform' weights all points equally. 'distance' weights points by the inverse of their distance."
+    )
+    algorithm: KNNAlgorithmType = Field(
+        default='auto',
+        description="Algorithm used to compute the nearest neighbors."
+    )
+    leaf_size: int = Field(
+        default=30,
+        description="Leaf size passed to BallTree or KDTree. This can affect the speed of the construction and query, as well as the memory required to store the tree.",
+        gt=0
+    )
+    p: int = Field(
+        default=2,
+        description="Power parameter for the Minkowski metric. When p=1, this is equivalent to using manhattan_distance (L1), and euclidean_distance (L2) for p=2. For arbitrary p, minkowski_distance (Lp) is used.",
+        ge=1
+    )
+    metric: KNNMetricType = Field(
+        default='minkowski',
+        description="The distance metric to use for the tree. The default metric is minkowski, and with p=2 is equivalent to the standard Euclidean metric."
+    )

--- a/api/pydantic_schemas/configs/kmeans_config.py
+++ b/api/pydantic_schemas/configs/kmeans_config.py
@@ -1,0 +1,49 @@
+from typing import Literal
+
+from pydantic import Field
+from api.pydantic_schemas.configs.algorithm_configs import UnsupervisedAlgorithmsParams
+
+# Define custom types for clarity, mirroring the dataclass version
+InitMethodType = Literal["k-means++", "random"]
+MetricType = Literal["euclidean", "manhattan"]
+
+class KMeansParams(UnsupervisedAlgorithmsParams):
+    """
+    Pydantic model for K-Means clustering algorithm parameters.
+
+    Attributes:
+        n_clusters: Number of clusters to form (default: 8). Must be positive.
+        max_iter: Maximum number of iterations of the k-means algorithm (default: 300). Must be positive.
+        tol: Tolerance to declare convergence (default: 1e-4). Must be positive.
+        init_method: Method for initialization of centroids ('k-means++', 'random') (default: 'random').
+        initialization_runs: Number of times the k-means algorithm will be run with different centroid seeds (default: 10). Must be positive.
+        metric: Distance metric to use ('euclidean', 'manhattan') (default: 'euclidean').
+    """
+    n_clusters: int = Field(
+        default=8,
+        description="Number of clusters to form.",
+        gt=0
+    )
+    max_iter: int = Field(
+        default=300,
+        description="Maximum number of iterations of the k-means algorithm for a single run.",
+        gt=0
+    )
+    tol: float = Field(
+        default=1e-4,
+        description="Relative tolerance with regards to Frobenius norm of the difference in the cluster centers of two consecutive iterations to declare convergence.",
+        gt=0
+    )
+    init_method: InitMethodType = Field(
+        default="random",
+        description="Method for initialization: 'k-means++' : selects initial cluster centers for k-mean clustering in a smart way to speed up convergence. 'random': choose n_clusters observations (rows) at random from data for the initial centroids."
+    )
+    initialization_runs: int = Field(
+        default=10,
+        description="Number of times the k-means algorithm will be run with different centroid seeds. The final results will be the best output of n_init consecutive runs in terms of inertia.",
+        gt=0
+    )
+    metric: MetricType = Field(
+        default="euclidean",
+        description="Distance metric to use. 'euclidean' or 'manhattan'."
+    )

--- a/api/pydantic_schemas/configs/logistic_regression_config.py
+++ b/api/pydantic_schemas/configs/logistic_regression_config.py
@@ -1,0 +1,24 @@
+from pydantic import Field
+from api.pydantic_schemas.configs.algorithm_configs import GradientBasedParams
+
+
+class LogisticRegressionParams(GradientBasedParams):
+    """
+    Pydantic model for Logistic Regression algorithm parameters.
+    This model parameter configuration defines the types and possible default arguments
+    used by the Logistic Regression model. Inherits GradientBasedParams.
+
+    Attributes:
+        threshold: Decision threshold for converting probabilities to class labels (default: 0.5). Must be between 0 and 1 (exclusive).
+        # Parameters like learning_rate, epochs, batch_size, reg_type, reg_strength, mixing_ratio
+        # are inherited from GradientBasedParams.
+        # Loss is typically binary cross-entropy/log loss for logistic regression
+        # and is usually not configurable in the same way as regression loss.
+    """
+
+    threshold: float = Field(
+        default=0.5,
+        description="Decision threshold for converting probabilities to class labels.",
+        gt=0.0,
+        lt=1.0
+    )

--- a/api/pydantic_schemas/configs/naive_bayes_config.py
+++ b/api/pydantic_schemas/configs/naive_bayes_config.py
@@ -1,0 +1,36 @@
+from typing import Optional, List
+
+from pydantic import Field
+from api.pydantic_schemas.configs.algorithm_configs import SupervisedAlgorithmsParams
+
+
+class NaiveBayesParams(SupervisedAlgorithmsParams):
+    """
+    Pydantic model for Naive Bayes algorithm parameters.
+    This model parameters config defines types and possible default arguments used by Naive Bayes model.
+
+    Attributes:
+        alpha: Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing). (default: 1.0)
+        binarize: Threshold for binarizing (mapping to booleans) of sample features. If None, input is presumed to be already binary. (default: 0.0)
+        fit_prior: Whether to learn class prior probabilities or not. If false, a uniform prior will be used. (default: True)
+        class_prior: Prior probabilities of the classes. If specified the priors are not adjusted according to the data. (default: None)
+    """
+
+    alpha: float = Field(
+        default=1.0,
+        description="Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).",
+        ge=0.0
+    )
+    binarize: Optional[float] = Field(
+        default=0.0,
+        description="Threshold for binarizing (mapping to booleans) of sample features. If None, input is presumed to be already binary. Values greater than the threshold are set to 1 and values less than or equal to the threshold are set to 0.",
+        ge=0.0
+    )
+    fit_prior: bool = Field(
+        default=True,
+        description="Whether to learn class prior probabilities or not. If false, a uniform prior will be used."
+    )
+    class_prior: Optional[List[float]] = Field(
+        default=None,
+        description="Prior probabilities of the classes. If specified the priors are not adjusted according to the data. The number of elements in class_prior must match the number of classes."
+    )


### PR DESCRIPTION
This commit converts several algorithm parameter configurations from dataclasses (in `api/schemas/configs/`) to Pydantic models (in `api/pydantic_schemas/configs/`) and registers them in the FastAPI application (`api/main.py`).

The following algorithms were migrated and registered:
- Decision Tree
- K-Nearest Neighbours
- K-Means Clustering
- Logistic Regression
- Naive Bayes